### PR TITLE
Rework command parsing

### DIFF
--- a/e2e/exec.test.ts
+++ b/e2e/exec.test.ts
@@ -34,7 +34,7 @@ describe('jill exec', () => void withPackageManager((packageManager) => {
 
   // Tests
   it('should run node in wks-c', async () => {
-    const res = await jill('exec -w wks-c node -- -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
+    const res = await jill('exec -w wks-c node -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
 
     // Check jill output
     expect(res.code).toBe(0);
@@ -49,7 +49,7 @@ describe('jill exec', () => void withPackageManager((packageManager) => {
   });
 
   it('should be the default command', async () => {
-    const res = await jill('-w wks-c node -- -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
+    const res = await jill('-w wks-c node -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
 
     // Check jill output
     expect(res.code).toBe(0);
@@ -60,7 +60,7 @@ describe('jill exec', () => void withPackageManager((packageManager) => {
   });
 
   it('should run wks-c fails script and exit 1', async () => {
-    const res = await jill('exec -w wks-c node -- -e "process.exit(1)"', { cwd: prjDir, removeCotes: true });
+    const res = await jill('exec -w wks-c node -e "process.exit(1)"', { cwd: prjDir, removeCotes: true });
 
     // Check jill output
     expect(res.code).toBe(1);
@@ -71,7 +71,7 @@ describe('jill exec', () => void withPackageManager((packageManager) => {
   });
 
   it('should run wks-b start script and build script', async () => {
-    const res = await jill('-w wks-b node -- -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
+    const res = await jill('-w wks-b node -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
 
     // Check jill output
     expect(res.code).toBe(0);
@@ -91,7 +91,7 @@ describe('jill exec', () => void withPackageManager((packageManager) => {
   });
 
   it('should print task plan and do not run any script', async () => {
-    const res = await jill('-w wks-b --plan --plan-mode json node -- -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
+    const res = await jill('-w wks-b --plan --plan-mode json node -e "require(\'node:fs\').writeFileSync(\'script.txt\', \'node\')"', { cwd: prjDir, removeCotes: true });
 
     // Check jill plan
     expect(res.code).toBe(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jujulego/jill",
-  "version": "2.2.0-alpha.7",
+  "version": "2.2.0-alpha.8",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/commands/each.tsx
+++ b/src/commands/each.tsx
@@ -55,6 +55,7 @@ export class EachCommand extends TaskCommand<IEachCommandArgs> {
       // Run options
       .positional('script', { type: 'string', demandOption: true })
       .option('deps-mode', {
+        alias: 'd',
         choice: ['all', 'prod', 'none'],
         default: 'all' as const,
         desc: 'Dependency selection mode:\n' +
@@ -86,6 +87,12 @@ export class EachCommand extends TaskCommand<IEachCommandArgs> {
         default: 'master',
         group: 'Filters:',
         desc: 'Fallback revision, used if no revision matching the given format is found',
+      })
+
+      // Config
+      .strict(false)
+      .parserConfiguration({
+        'unknown-options-as-args': true,
       });
   }
 

--- a/src/commands/exec.tsx
+++ b/src/commands/exec.tsx
@@ -40,9 +40,14 @@ export class ExecCommand extends TaskCommand<IExecCommandArgs> {
           ' - prod = dependencies\n' +
           ' - none = nothing'
       })
+
+      // Documentation
       .example('jill eslint', '')
       .example('jill eslint --env-info', 'Unknown arguments are passed down to command. Here it would run eslint --env-info')
       .example('jill eslint -- -v', 'You can use -- to stop argument parsing. Here it would run eslint -v')
+
+      // Config
+      .strict(false)
       .parserConfiguration({
         'unknown-options-as-args': true,
       });

--- a/src/commands/group.tsx
+++ b/src/commands/group.tsx
@@ -46,6 +46,7 @@ export class GroupCommand extends TaskCommand<IGroupCommandArgs> {
         }
       })
       .option('deps-mode', {
+        alias: 'd',
         choice: ['all', 'prod', 'none'],
         default: 'all' as const,
         desc: 'Dependency selection mode:\n' +

--- a/src/commands/run.tsx
+++ b/src/commands/run.tsx
@@ -42,12 +42,19 @@ export class RunCommand extends TaskCommand<IRunCommandArgs> {
     return this.addTaskOptions(parser)
       .positional('script', { type: 'string', demandOption: true })
       .option('deps-mode', {
+        alias: 'd',
         choice: ['all', 'prod', 'none'],
         default: 'all' as const,
         desc: 'Dependency selection mode:\n' +
           ' - all = dependencies AND devDependencies\n' +
           ' - prod = dependencies\n' +
           ' - none = nothing'
+      })
+
+      // Config
+      .strict(false)
+      .parserConfiguration({
+        'unknown-options-as-args': true,
       });
   }
 

--- a/src/jill.application.ts
+++ b/src/jill.application.ts
@@ -50,9 +50,7 @@ export class JillApplication {
 
     return this.parser
       .command(commands)
-      .demandCommand()
       .recommendCommands()
-      .strict()
       .fail(false);
   }
 

--- a/src/jill.application.ts
+++ b/src/jill.application.ts
@@ -51,6 +51,7 @@ export class JillApplication {
     return this.parser
       .command(commands)
       .recommendCommands()
+      .strict()
       .fail(false);
   }
 

--- a/src/modules/task-command.tsx
+++ b/src/modules/task-command.tsx
@@ -3,17 +3,18 @@ import { plan as extractPlan, type Task, type TaskManager, TaskSet, type TaskSum
 import { injectable } from 'inversify';
 import { type ArgumentsCamelCase, type Argv } from 'yargs';
 
-import { lazyInject } from '@/src/inversify.config';
+import { Logger } from '@/src/commons/logger.service';
+import { container, lazyInject } from '@/src/inversify.config';
 import { isCommandCtx } from '@/src/tasks/command-task';
 import { isScriptCtx } from '@/src/tasks/script-task';
 import { TASK_MANAGER } from '@/src/tasks/task-manager.config';
 import { type AwaitableGenerator } from '@/src/types';
 import List from '@/src/ui/list';
 import TaskManagerSpinner from '@/src/ui/task-manager-spinner';
+import { ExitException } from '@/src/utils/exit';
 import { printJson } from '@/src/utils/json';
 
 import { InkCommand } from './ink-command';
-import { ExitException } from '@/src/utils/exit';
 
 // Types
 export interface ITaskCommandArgs {
@@ -82,6 +83,9 @@ export abstract class TaskCommand<A = unknown> extends InkCommand<A> {
       if (result.failed > 0) {
         throw new ExitException(1);
       }
+    } else {
+      const logger = container.get(Logger);
+      logger.warn`No task found`;
     }
   }
 }

--- a/tests/commands/exec.test.tsx
+++ b/tests/commands/exec.test.tsx
@@ -35,7 +35,7 @@ beforeEach(async () => {
 
   bed = new TestBed();
   wks = bed.addWorkspace('wks');
-  task = new TestCommandTask(wks, 'cmd', ['--arg'], { logger: spyLogger });
+  task = new TestCommandTask(wks, 'cmd', [], { logger: spyLogger });
 
   app = render(<Layout />);
   container.rebind(INK_APP).toConstantValue(wrapInkTestApp(app));
@@ -66,16 +66,16 @@ describe('jill exec', () => {
     // Run command
     const prom = yargs.command(command)
       .fail(false)
-      .parse('-w wks cmd -- --arg');
+      .parse('cmd');
 
     await flushPromises();
 
     // should create script task then add it to manager
-    expect(wks.exec).toHaveBeenCalledWith('cmd', ['--arg'], { buildDeps: 'all' });
+    expect(wks.exec).toHaveBeenCalledWith('cmd', [], { buildDeps: 'all' });
     expect(manager.add).toHaveBeenCalledWith(task);
 
     // should print task spinner
-    expect(app.lastFrame()).toEqual(expect.ignoreColor(/^. cmd --arg/));
+    expect(app.lastFrame()).toEqual(expect.ignoreColor(/^. cmd/));
 
     // complete task
     jest.spyOn(task, 'status', 'get').mockReturnValue('done');
@@ -85,7 +85,7 @@ describe('jill exec', () => {
     await prom;
 
     // should print task completed
-    expect(app.lastFrame()).toEqual(expect.ignoreColor(`${symbols.success} cmd --arg (took 100ms)`));
+    expect(app.lastFrame()).toEqual(expect.ignoreColor(`${symbols.success} cmd (took 100ms)`));
   });
 
   it('should use given dependency selection mode', async () => {
@@ -94,12 +94,54 @@ describe('jill exec', () => {
     // Run command
     const prom = yargs.command(command)
       .fail(false)
-      .parse('exec -w wks --deps-mode prod cmd -- --arg');
+      .parse('exec -d prod cmd');
 
     await flushPromises();
 
     // should create script task than add it to manager
-    expect(wks.exec).toHaveBeenCalledWith('cmd', ['--arg'], { buildDeps: 'prod' });
+    expect(wks.exec).toHaveBeenCalledWith('cmd', [], { buildDeps: 'prod' });
+
+    // complete task
+    jest.spyOn(task, 'status', 'get').mockReturnValue('done');
+    task.emit('status.done', { status: 'done', previous: 'running' });
+    task.emit('completed', { status: 'done', duration: 100 });
+
+    await prom;
+  });
+
+  it('should pass down unknown arguments', async () => {
+    context.reset();
+
+    // Run command
+    const prom = yargs.command(command)
+      .fail(false)
+      .parse('cmd --arg');
+
+    await flushPromises();
+
+    // should create script task than add it to manager
+    expect(wks.exec).toHaveBeenCalledWith('cmd', ['--arg'], { buildDeps: 'all' });
+
+    // complete task
+    jest.spyOn(task, 'status', 'get').mockReturnValue('done');
+    task.emit('status.done', { status: 'done', previous: 'running' });
+    task.emit('completed', { status: 'done', duration: 100 });
+
+    await prom;
+  });
+
+  it('should pass down unparsed arguments', async () => {
+    context.reset();
+
+    // Run command
+    const prom = yargs.command(command)
+      .fail(false)
+      .parse('cmd -- -v');
+
+    await flushPromises();
+
+    // should create script task than add it to manager
+    expect(wks.exec).toHaveBeenCalledWith('cmd', ['-v'], { buildDeps: 'all' });
 
     // complete task
     jest.spyOn(task, 'status', 'get').mockReturnValue('done');

--- a/tests/commands/exec.test.tsx
+++ b/tests/commands/exec.test.tsx
@@ -136,12 +136,12 @@ describe('jill exec', () => {
     // Run command
     const prom = yargs.command(command)
       .fail(false)
-      .parse('cmd -- -v');
+      .parse('cmd -- -d toto');
 
     await flushPromises();
 
     // should create script task than add it to manager
-    expect(wks.exec).toHaveBeenCalledWith('cmd', ['-v'], { buildDeps: 'all' });
+    expect(wks.exec).toHaveBeenCalledWith('cmd', ['-d', 'toto'], { buildDeps: 'all' });
 
     // complete task
     jest.spyOn(task, 'status', 'get').mockReturnValue('done');

--- a/tests/commands/group.test.tsx
+++ b/tests/commands/group.test.tsx
@@ -73,7 +73,7 @@ describe('jill group', () => {
     // Run command
     const prom = yargs.command(command)
       .fail(false)
-      .parse('group -w wks test1 // test2');
+      .parse('group test1 // test2');
 
     await flushPromises();
 
@@ -119,7 +119,7 @@ describe('jill group', () => {
     // Run command
     const prom = yargs.command(command)
       .fail(false)
-      .parse('group -w wks --deps-mode prod test1 // test2');
+      .parse('group -d prod test1 // test2');
 
     await flushPromises();
 

--- a/tests/modules/task-command.test.tsx
+++ b/tests/modules/task-command.test.tsx
@@ -15,6 +15,7 @@ import { printJson } from '@/src/utils/json';
 import { TestBed } from '@/tools/test-bed';
 import { TestScriptTask } from '@/tools/test-tasks';
 import { flushPromises, spyLogger, wrapInkTestApp } from '@/tools/utils';
+import { Logger } from '@/src/commons/logger.service';
 
 // Class
 @injectable()
@@ -93,8 +94,6 @@ describe('TaskCommand', () => {
     });
 
     it('should exit 1 if a task fails', async () => {
-      jest.spyOn(process, 'exit').mockImplementation();
-
       // Run command
       const prom = command.handler({ $0: 'jill', _: [] });
       await flushPromises();
@@ -108,6 +107,21 @@ describe('TaskCommand', () => {
 
       // should print task failed
       expect(app.lastFrame()).toEqual(expect.ignoreColor(`${symbols.error} Running cmd in wks (took 100ms)`));
+    });
+
+    it('should log and exit if no task were yielded', async () => {
+      const logger = container.get(Logger);
+
+      jest.spyOn(logger, 'warn').mockImplementation();
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      jest.mocked(command.prepare).mockImplementation(function* () {});
+
+      // Run command
+      await command.handler({ $0: 'jill', _: [] });
+
+      // should have only logged
+      expect(manager.add).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(['No task found']);
     });
   });
 

--- a/tests/modules/task-command.test.tsx
+++ b/tests/modules/task-command.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render } from 'ink-testing-library';
 import { injectable } from 'inversify';
 import symbols from 'log-symbols';
 
+import { Logger } from '@/src/commons/logger.service';
 import { INK_APP } from '@/src/ink.config';
 import { container } from '@/src/inversify.config';
 import { TaskCommand } from '@/src/modules/task-command';
@@ -15,7 +16,6 @@ import { printJson } from '@/src/utils/json';
 import { TestBed } from '@/tools/test-bed';
 import { TestScriptTask } from '@/tools/test-tasks';
 import { flushPromises, spyLogger, wrapInkTestApp } from '@/tools/utils';
-import { Logger } from '@/src/commons/logger.service';
 
 // Class
 @injectable()


### PR DESCRIPTION
Closes #574 

Do not use `halt-at-non-option` (yargs do not parse after the command). Instead pass down unknown arguments to command/script.